### PR TITLE
Resolved #12: Altered type of meeting_number column to BIGINT. 

### DIFF
--- a/models/initialize_db.sql
+++ b/models/initialize_db.sql
@@ -16,4 +16,6 @@ CREATE TABLE meeting_logs(
 	
 SET timezone = 'US/Eastern';
 
+ALTER TABLE meeting_logs ALTER COLUMN meeting_number TYPE BIGINT;
+
 INSERT INTO meeting_logs(meeting_number, meeting_password,  user_name, email, ip_address, meeting_join_time,    meeting_leave_time, user_type, meeting_host, meeting_ended) VALUES (1122442342, '019233', 'test_user', NULL, '192.168.0.1/24', '2020-03-18 06:05:06 US/Eastern','2020-03-18 06:35:06 US/Eastern','researcher',true,true);


### PR DESCRIPTION
Users needs to manually run
```ALTER TABLE meeting_logs ALTER COLUMN meeting_number TYPE BIGINT;```
on their local machine psql database since we don't have migrations right now.

You should be able to start meetings with meeting_numbers > 2^32 now. (Zoom has 10 digit meeting numbers so anything above 4.3 billion would have cause the issues since 2^32 is roughly 4.3 billion)