### PR TITLE
Resolved #6: Added migrations to create and update database from scratch

### DIFF
--- a/migrations/1-init.js
+++ b/migrations/1-init.js
@@ -1,0 +1,7 @@
+const createRoleEnum = require("./helpers/create-role-enum");
+const createMeetingLogsTable = require("./helpers/create-meeting-logs-table");
+const insertTestData = require("./helpers/insert-test-data");
+
+module.exports.generateSql = () => `${createRoleEnum} 
+${createMeetingLogsTable} 
+${insertTestData}`

--- a/migrations/helpers/create-meeting-logs-table.js
+++ b/migrations/helpers/create-meeting-logs-table.js
@@ -1,0 +1,16 @@
+module.exports = `
+CREATE TABLE meeting_logs(
+    meeting_id SERIAL PRIMARY KEY,
+    meeting_number BIGINT NOT NULL,
+    meeting_password VARCHAR(10),
+    user_name VARCHAR(45) NOT NULL,
+    email VARCHAR(100),
+    ip_address inet,
+    meeting_join_time timestamptz,
+    meeting_leave_time timestamptz,
+    user_type user_role,
+    meeting_host BOOLEAN NOT NULL,
+    meeting_ended BOOLEAN NOT NULL
+);
+SET timezone = 'US/Eastern';
+`

--- a/migrations/helpers/create-role-enum.js
+++ b/migrations/helpers/create-role-enum.js
@@ -1,0 +1,1 @@
+module.exports = `CREATE TYPE user_role AS ENUM ('researcher', 'participant');`

--- a/migrations/helpers/insert-test-data.js
+++ b/migrations/helpers/insert-test-data.js
@@ -1,0 +1,1 @@
+module.exports = `INSERT INTO meeting_logs(meeting_number, meeting_password,  user_name, email, ip_address, meeting_join_time, meeting_leave_time, user_type, meeting_host, meeting_ended) VALUES (1122442342, '019233', 'test_user', NULL, '192.168.0.1/24', '2020-03-18 06:05:06 US/Eastern','2020-03-18 06:35:06 US/Eastern','researcher',true,true);`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7567,6 +7567,15 @@
         "xtend": "^4.0.0"
       }
     },
+    "postgres-migrations": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-4.0.3.tgz",
+      "integrity": "sha512-k6+ikiS2ZDJS/1fRsbms7N43nUIxlWswHGma0b8HcRkJil/QyEN+gw7yQ2Zu34EpR+TrHNOjV0oqUNMLZupoVw==",
+      "requires": {
+        "pg": "^7.18.2",
+        "sql-template-strings": "^2.2.2"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -9261,6 +9270,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sql-template-strings": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/sql-template-strings/-/sql-template-strings-2.2.2.tgz",
+      "integrity": "sha1-PxFQiiWt384hejBCqdMAwxk7lv8="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jquery": "^3.4.1",
     "lodash": "^4.17.14",
     "pg": "^7.18.2",
+    "postgres-migrations": "^4.0.3",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-redux": "7.1.0",

--- a/queries.js
+++ b/queries.js
@@ -1,13 +1,27 @@
 var dotenv = require('dotenv').config({path: __dirname + '/.env'});
 const Pool = require('pg').Pool
+const {createDb, migrate} = require("postgres-migrations")
 
-const pool = new Pool({
+
+const dbConfig = {
   user: dotenv.parsed.USER,
   host: dotenv.parsed.DB_URL,
   database: dotenv.parsed.DATABASE,
   password: dotenv.parsed.PASSWORD,
-  port: dotenv.parsed.DB_PORT,
-})
+  port: parseInt(dotenv.parsed.DB_PORT),
+}
+
+const pool = new Pool(dbConfig)
+
+function createAndMigrateDB() {
+    createDb(dotenv.parsed.DATABASE, dbConfig).then(() => {
+        return migrate(dbConfig, "migrations")
+        // "migrations" is the path where all the migration files are contained
+    }).then(() => {} )
+    .catch((err) => {
+        console.log(err)
+    })
+}
 
 const getAllMeetingLogs = (request, response) => {
   pool.query('SELECT * FROM meeting_logs WHERE meeting_host=true ORDER BY meeting_id ASC', (error, results) => {
@@ -102,4 +116,5 @@ module.exports = {
   createMeetingLog,
   deleteMeetingLog,
   updateMeetingLogEndedServer,
+  createAndMigrateDB,
 }

--- a/server.js
+++ b/server.js
@@ -21,6 +21,9 @@ var http = require('http').createServer(app);
 var io = require('socket.io')(http)
 const compiler = webpack(config);
 
+//Intialize DB and migrations
+db.createAndMigrateDB();
+
 // socket related variables
 
 //Object storing users connected to the server


### PR DESCRIPTION
Change the database name in your .env file to something like "migrations-test". This is to simulate an unitialized database. Run `nodemon server`. Schedule and join a call as a researcher or participant. You should now see records in the meeting_logs table for these users in the new "migrations-test" database.